### PR TITLE
Add relationship between Fund and AssetClass

### DIFF
--- a/app/models/asset_class.rb
+++ b/app/models/asset_class.rb
@@ -1,3 +1,5 @@
 class AssetClass < ApplicationRecord
   validates :name, presence: true, uniqueness: true
+  has_many :funds, through: :asset_class_sections
+  has_many :asset_class_sections
 end

--- a/app/models/asset_class_section.rb
+++ b/app/models/asset_class_section.rb
@@ -1,0 +1,4 @@
+class AssetClassSection < ApplicationRecord
+  belongs_to :fund
+  belongs_to :asset_class
+end

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -1,6 +1,8 @@
 class Fund < ApplicationRecord
   validates :ticker, presence: true, uniqueness: true
   has_many :fund_sections, dependent: :destroy
+  has_many :asset_classes, through: :asset_class_sections
+  has_many :asset_class_sections
 
   def get_share_price
     get_quote.l.to_d

--- a/db/migrate/20180121161207_create_asset_class_sections.rb
+++ b/db/migrate/20180121161207_create_asset_class_sections.rb
@@ -1,0 +1,13 @@
+class CreateAssetClassSections < ActiveRecord::Migration[5.1]
+  def change
+    create_table :asset_class_sections do |t|
+      t.bigint "fund_id", null: false
+      t.bigint "asset_class_id", null: false
+      t.decimal "percentage", default: "0.0", null: false
+      t.datetime "percentage_at"
+      t.index ["asset_class_id", "fund_id"], name: "index_asset_classes_funds_on_asset_class_id_and_fund_id"
+      t.index ["fund_id", "asset_class_id"], name: "index_asset_classes_funds_on_fund_id_and_asset_class_id"
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180121132045) do
+ActiveRecord::Schema.define(version: 20180121161207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "asset_class_sections", force: :cascade do |t|
+    t.bigint "fund_id", null: false
+    t.bigint "asset_class_id", null: false
+    t.decimal "percentage", default: "0.0", null: false
+    t.datetime "percentage_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["asset_class_id", "fund_id"], name: "index_asset_classes_funds_on_asset_class_id_and_fund_id"
+    t.index ["fund_id", "asset_class_id"], name: "index_asset_classes_funds_on_fund_id_and_asset_class_id"
+  end
 
   create_table "asset_classes", force: :cascade do |t|
     t.string "name"

--- a/spec/factories/asset_class_sections.rb
+++ b/spec/factories/asset_class_sections.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :asset_class_section do
+    percentage 5.5
+    association :asset_class
+    association :fund
+  end
+end

--- a/spec/models/asset_class_section_spec.rb
+++ b/spec/models/asset_class_section_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe AssetClassSection, type: :model do
+  it { should belong_to(:fund) }
+  it { should belong_to(:asset_class) }
+
+  describe 'assocation sanity check' do
+    it 'has assocations with AssetClass and Fund' do
+      a_c_s = create(:asset_class_section)
+
+      expect(a_c_s.asset_class)
+      expect(a_c_s.fund)
+    end
+  end
+end

--- a/spec/models/asset_class_spec.rb
+++ b/spec/models/asset_class_spec.rb
@@ -3,4 +3,6 @@ require 'rails_helper'
 RSpec.describe AssetClass, type: :model do
   it { should validate_presence_of(:name) }
   it { should validate_uniqueness_of(:name) }
+  it { should have_many(:funds) } # which funds can I buy to get bonds, etc.
+  it { should have_many(:asset_class_sections) } # May not need to call directly
 end

--- a/spec/models/fund_spec.rb
+++ b/spec/models/fund_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Fund, type: :model do
   it { should validate_uniqueness_of(:ticker) }
   it { should validate_presence_of(:ticker) }
   it { should have_many(:fund_sections) }
+  it { should have_many(:asset_classes) }
+  it { should have_many(:asset_class_sections) }
 
   describe '#get_share_price', :vcr do
     it 'gets the share price' do


### PR DESCRIPTION
* A fund can be made up of many AssetClasses. This is a many to many
since multiple funds contain the same asset class. We may want to start
with an asset class and look up which funds would give us some of that
asset class: e.g. "I need more bonds in my portfolio, which funds offer
bonds"
* This relationship requires more than just a join table and the Rails
has_and_belongs_to_many relationship. The model between the two must
also carry some meta information. We want to know what percentage of a
Fund are a certain asset class. This means the relationship should be a
has_many through. The model that joins the two is called
AssetClassSection for consistency with FundSection. Now I wish I used
the word "Component" instead of "Section". Oh well.
* Should-matchers do not actually check the database setup which is a
bit annoying. Hence the sanity check.

***Planning***
* AssetClassSections for a particular fund may not have a restriction
preventing them from adding up to over 100% since there may be different
ways to slice and dice. So there should be some validation maybe in a
future Goal model that ensures one does not have redundant slices: e.g.
A portfolio balancing
* All bonds
* Government Bonds
* Stock

The first two overlap